### PR TITLE
Embed tilemap in binary

### DIFF
--- a/assets/terrain.tmx
+++ b/assets/terrain.tmx
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.8" tiledversion="1.8.1" orientation="orthogonal" renderorder="right-down" width="64" height="32" tilewidth="16" tileheight="16" infinite="0" nextlayerid="4" nextobjectid="1">
- <tileset firstgid="1" source="terrain.tsx"/>
+ <tileset firstgid="1" name="terrain" tilewidth="16" tileheight="16" tilecount="48" columns="16">
+  <image source="terrain.png" width="256" height="48"/>
+ </tileset>
  <layer id="2" name="water" width="64" height="32" locked="1">
   <data encoding="csv">
 3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,

--- a/assets/terrain.tsx
+++ b/assets/terrain.tsx
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<tileset version="1.8" tiledversion="1.8.1" name="terrain" tilewidth="16" tileheight="16" tilecount="48" columns="16">
- <image source="terrain.png" width="256" height="48"/>
-</tileset>

--- a/src/tilemap.rs
+++ b/src/tilemap.rs
@@ -1,11 +1,9 @@
 use bevy::prelude::*;
-use std::path::Path;
 
 pub const TILE_SIZE: usize = 16;
 
-// TODO: get assets path from asset system, or even use asset system for loading
-const MAP_PATH: &str = "assets/terrain.tmx";
 const TILESET_ASSET: &str = "terrain.png";
+const TILEMAP_TMX: &[u8] = include_bytes!("../assets/terrain.tmx");
 
 const COLLISION_LAYER_NAME: &str = "collision";
 
@@ -50,7 +48,7 @@ pub fn load_map(
     asset_server: Res<AssetServer>,
     mut texture_atlases: ResMut<Assets<TextureAtlas>>,
 ) {
-    let map = tiled::parse_file(Path::new(MAP_PATH)).unwrap();
+    let map = tiled::parse(TILEMAP_TMX).unwrap();
     let texture = asset_server.load(TILESET_ASSET);
     let texture_atlas = TextureAtlas::from_grid(
         texture,


### PR DESCRIPTION
closes #5

- Embed `.tmx` file content directly into binary as static `&[u8]`instead of loading from filesystem. Filesystem is not available in web target and loading assets in web is [not that easy](https://github.com/bevyengine/bevy/blob/f3de12bc5e03c58a9b863943b8db84a321422bec/crates/bevy_asset/src/io/wasm_asset_io.rs#L23-L35).
- Embed `.tsx` into `.tmx` instead of using separate file